### PR TITLE
Add 'Cache-Control' header for static files on S3

### DIFF
--- a/packages/serverless-nuxt-plugin/src/index.js
+++ b/packages/serverless-nuxt-plugin/src/index.js
@@ -126,7 +126,7 @@ class ServerlessNuxtPlugin {
         Body: fs.readFileSync(file),
         ACL: 'public-read',
         ContentType: mime.lookup(file) || null,
-        CacheControl: 'public, max-age=31536000' // let the browser cache all static files for 1 year since they receive a unique hash by Nuxt
+        CacheControl: 'public, max-age=31536000', // let the browser cache all static files for 1 year since they receive a unique hash by Nuxt
       }).promise()
     }))
 

--- a/packages/serverless-nuxt-plugin/src/index.js
+++ b/packages/serverless-nuxt-plugin/src/index.js
@@ -126,6 +126,7 @@ class ServerlessNuxtPlugin {
         Body: fs.readFileSync(file),
         ACL: 'public-read',
         ContentType: mime.lookup(file) || null,
+        CacheControl: 'public, max-age=31536000' // let the browser cache all static files for 1 year since they receive a unique hash by Nuxt
       }).promise()
     }))
 


### PR DESCRIPTION
**What issue does this PR address:**
I recently did an audit on my page and noticed that the uploaded static assets on S3 do not have an efficient cache policy, which decreases the performance of a page. See the screeenshot:

![image](https://user-images.githubusercontent.com/19409640/76987953-4b492980-6944-11ea-890e-a6026072cb3a.png)

**How this PR fixes this issue:**
I added the `Cache-Control` metadata to the uploaded static assets so AWS will add a `Cache-Control` header to the response of a requested static file. I selected a TTL of 1 year for the files since all static files receive a unique content hash as the file name by the Nuxt build, whereby a file would receive a new name as soon as its content changes. See here for details: https://nuxtjs.org/api/configuration-build#filenames

**Further improvements:**
It might be useful to have different cache TTLs for different file types. I couldn't think of a use case but there might are some. Additionally, it could make sense to make the TTL configurable in the serverless `custom` vars. Tell me what you think :) 