### PR TITLE
Added memorySize to serverless.yml

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -139,6 +139,7 @@ resources:
 
 functions:
   nuxt:
+    memorySize: 2048
     timeout: 30
     handler: handler.render
     events:


### PR DESCRIPTION
Using the Lambda power tuning Step Function, I was able to determine that 2048MB is the ideal balance between cost & performance. Upping the memory from 1024MB to 2048MB resulted in a very noticeable performance boost!