### PR TITLE
Resolve serverless framework deprecation warning

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,8 +96,7 @@ Create a `serverless.yml` file. Use the Cloud Formations to upload **assets**(`.
 Write your plugin settings in the `custom.nuxt` field. The version(`custom.nuxt.version`) is used as a prefix when uploading assets files to S3.
 
 ```yml
-service:
-  name: my-nuxt-project # your project name
+service: my-nuxt-project # your project name
 
 plugins:
   - serverless-nuxt-plugin


### PR DESCRIPTION
This commit resolves the deprecation warning by serverless framework:
Serverless: Deprecation warning: Starting from next major object notation for "service" property will no longer be recognized. Set "service" property directly with service name.
            More Info: https://www.serverless.com/framework/docs/deprecations/#SERVICE_OBJECT_NOTATION